### PR TITLE
Redesign blog with Terminal aesthetic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/app/design.md
+++ b/app/design.md
@@ -1,0 +1,106 @@
+# Design system — Reveries of a software engineer
+
+> **The Terminal.** A dark, monospace, command-line reading experience for a software
+> engineer's blog. One typeface (JetBrains Mono), one paper (near-black teal), one accent
+> (phosphor green) with an amber secondary. Every page reads like a shell session.
+>
+> This file is the locked design system for the Gatsby app in `app/`. It was produced by a
+> `hallmark redesign` pass. Subsequent design work defers to it — pages share the system;
+> they do not diverge. Tokens live in [`src/tokens.css`](./src/tokens.css) and are consumed
+> by name in [`src/style.css`](./src/style.css).
+
+```
+/* Hallmark · genre: technical · macrostructure: Workbench + Long Document
+ * theme: Terminal (dark paper · mono · phosphor) · nav: N8 terminal · footer: status bar
+ * design-system: design.md · designed-as-app
+ */
+```
+
+## Picks
+
+| Axis | Value |
+| --- | --- |
+| Genre | technical |
+| Theme | Terminal — dark paper · mono display · phosphor-green accent |
+| Macrostructure (home) | Workbench — index-as-shell (`whoami` hero + `ls -lt` listing) |
+| Macrostructure (article) | Long Document — reading view with `cat <file>.md` framing |
+| Nav archetype | N8 — terminal prompt (`roshangautam@blog:~/posts$`) |
+| Footer archetype | Status bar — sticky, file-context segments |
+| Typeface | JetBrains Mono only (400 / 500 / 700 / 800 + 400 italic) |
+| Motion | reduced to: caret blink · row rise-in · row hover-shift. ≤ 3 primitives. |
+
+Diversification is **inverted** for this project: every page must wear the same system. Do
+not rotate macrostructure/theme between pages — consistency is the goal.
+
+## Colour — dark, low-chroma teal paper + phosphor accent
+
+All values OKLCH. Tokens in `src/tokens.css`.
+
+| Token | Value | Role |
+| --- | --- | --- |
+| `--color-paper` | `oklch(17% 0.012 200)` | page background |
+| `--color-paper-2` | `oklch(21% 0.014 200)` | hover / blockquote fill |
+| `--color-paper-3` | `oklch(25% 0.016 200)` | raised surfaces |
+| `--color-ink` | `oklch(90% 0.02 160)` | primary text |
+| `--color-ink-2` | `oklch(72% 0.025 165)` | secondary text |
+| `--color-ink-3` | `oklch(58% 0.025 170)` | dim / metadata |
+| `--color-accent` | `oklch(86% 0.19 150)` | phosphor green — prompts, links, markers |
+| `--color-accent-dim` | `oklch(70% 0.14 152)` | dim green — prefixes |
+| `--color-amber` | `oklch(83% 0.13 75)` | amber — emphasis, blockquote rule |
+| `--color-rule` | `oklch(90% 0.02 160 / 0.12)` | hairline dividers |
+| `--color-code-bg` | `oklch(13% 0.012 200)` | code-block panel |
+| `--color-code-inline-bg` | `oklch(86% 0.19 150 / 0.10)` | inline code fill |
+
+A faint phosphor dot-grid (`radial-gradient`, 22px) sits under the whole page at 5% accent.
+
+## Type — one mono, sized by role
+
+`--font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;`
+
+All headings roman, `font-weight: 700`+, `font-style: normal` (no italic headers).
+Display name/title 800. Body 400. Row titles / lede 500. Italic survives only as body
+emphasis, recoloured amber.
+
+Scale: `--text-xs .76 · --text-sm .86 · --text-base .98 · --text-lg 1.18 · --text-xl 1.5 ·
+--text-2xl clamp(1.5,4.2vw,2.1) · --text-display clamp(1.9,6vw,3)rem`. Reading measure
+`--measure: 44rem`; shell wrap `--wrap: 64rem` (home) / `56rem` (article).
+
+## Components
+
+- **N8 terminal nav** (`.tnav`) — sticky, blurred. Left: `roshangautam@blog:~$` prompt
+  (`~/posts$` on article). Right: `./posts ./about ./rss ./github` links; `./` prefix dim,
+  hover → green.
+- **Status-bar footer** (`.statusbar`) — sticky bottom, blurred. Segments: file context
+  (`~/posts · 8 files · utf-8` / `<slug>.md · N words · utf-8`) · social nav · copyright.
+- **Hero** (`.hero`) — `❯ whoami` → name + blinking caret → `❯ cat about.txt` → blurb →
+  `#tag` chips.
+- **Listing** (`.listing`) — `❯ ls -lt ~/posts` then a 3-col grid (`date · title · .md`).
+  Rows hover-shift right with a `❯` reveal; collapse to one column < 640px.
+- **Article** (`.article`) — `❮ cd ~/posts` back-link · `❯ cat <slug>.md` cmd · title ·
+  meta line (`date:` / `read:` / `tags:` in dim green) · optional lede (amber-ruled) ·
+  `.prose` body · prev/next row.
+- **Prose** — `h2` prefixed `## ` (dim green); `ul` markers are green `-`; blockquotes
+  amber-left-rule on `--color-paper-2`; inline code green on tinted fill; fenced code =
+  dark panel, green left rule, `prism-tomorrow` tokens.
+
+## Motion
+
+`--ease-out: cubic-bezier(.16,1,.3,1)` · `--ease-in` · `--ease-in-out`; `--dur: 380ms`.
+Only three primitives: caret `blink`, row `rise` on enter, row hover background+shift.
+Animate `transform`/`opacity`/`background` only. All gated behind
+`prefers-reduced-motion: no-preference`.
+
+## Page recipes
+
+- **Home** (`src/pages/index.js`) — N8 nav · hero (`whoami`) · `ls -lt` listing · status bar.
+- **Article** (`src/templates/blog-post.js`) — N8 nav · back-link · `cat` header · lede
+  (from `description`) · prose · prev/next · status bar.
+- **404** (`src/pages/404.js`) — N8 nav · `cd` to a missing path → `no such file or
+  directory` → link back to `~/`.
+
+## Exports
+
+This is a plain-CSS Gatsby project (no Tailwind / no design-token pipeline), so the single
+portable export is **`src/tokens.css`** — every `--color-*`, `--font-*`, `--text-*`,
+`--space-*`, `--ease-*`, `--dur`, `--measure`, `--wrap` token used in the build. `style.css`
+imports it and references tokens by name; raw OKLCH values never appear outside `tokens.css`.

--- a/app/gatsby-browser.js
+++ b/app/gatsby-browser.js
@@ -1,10 +1,16 @@
-// custom typefaces
-import "typeface-montserrat"
-import "typeface-merriweather"
+// JetBrains Mono — the single typeface for the Terminal design system.
+// Weights: 400 (body) · 500 (titles) · 700 (headings) · 800 (display) · 400 italic (emphasis).
+import "@fontsource/jetbrains-mono/400.css"
+import "@fontsource/jetbrains-mono/500.css"
+import "@fontsource/jetbrains-mono/700.css"
+import "@fontsource/jetbrains-mono/800.css"
+import "@fontsource/jetbrains-mono/400-italic.css"
+
 // normalize CSS across browsers
 import "./src/normalize.css"
+
+// Syntax highlighting for fenced code blocks (dark theme, restyled in style.css)
+import "prismjs/themes/prism-tomorrow.css"
+
 // custom CSS styles
 import "./src/style.css"
-
-// Highlighting for code blocks
-import "prismjs/themes/prism.css"

--- a/app/gatsby-config.js
+++ b/app/gatsby-config.js
@@ -120,11 +120,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Gatsby Starter Blog`,
-        short_name: `GatsbyJS`,
+        name: `Reveries of a software engineer`,
+        short_name: `reveries`,
         start_url: `/`,
-        background_color: `#ffffff`,
-        theme_color: `#663399`,
+        background_color: `#131819`,
+        theme_color: `#131819`,
         display: `minimal-ui`,
         icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "0BSD",
       "dependencies": {
+        "@fontsource/jetbrains-mono": "^5.1.1",
         "gatsby": "^5.4.2",
         "gatsby-plugin-feed": "5.3.1",
         "gatsby-plugin-gatsby-cloud": "5.3.1",
@@ -29,9 +30,7 @@
         "prismjs": "1.27.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-helmet": "^6.1.0",
-        "typeface-merriweather": "1.1.13",
-        "typeface-montserrat": "1.1.13"
+        "react-helmet": "^6.1.0"
       },
       "devDependencies": {
         "ansi-regex": ">=5.0.1",
@@ -2065,6 +2064,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
@@ -21561,18 +21569,6 @@
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "node_modules/typeface-merriweather": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-merriweather/-/typeface-merriweather-1.1.13.tgz",
-      "integrity": "sha512-ho6xe/y/uHIKVXsFtK+dJfRCD5KZqJCMYTCcXfuCwQHQbeQ83a7hVkxfRMTEIjZOSXw5SevOjnwJuZ5QgWEHiw==",
-      "license": "MIT"
-    },
-    "node_modules/typeface-montserrat": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/typeface-montserrat/-/typeface-montserrat-1.1.13.tgz",
-      "integrity": "sha512-Pklkyj0e+K+6I/t0M6JBDBphpfJkF1k+3qd8qDnp9aVtCC7oGBQWTAcL6+5eArfGe7h73uPwyal73hEkf9YCUA==",
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "4.5.4",

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "node": ">=18.0.0"
    },  
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^5.1.1",
     "gatsby": "^5.4.2",
     "gatsby-plugin-feed": "5.3.1",
     "gatsby-plugin-gatsby-cloud": "5.3.1",
@@ -31,9 +32,7 @@
     "prismjs": "1.27.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-helmet": "^6.1.0",
-    "typeface-merriweather": "1.1.13",
-    "typeface-montserrat": "1.1.13"
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
     "babel-eslint": ">=10.0.0",

--- a/app/src/components/layout.js
+++ b/app/src/components/layout.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Link } from "gatsby"
 
-const Layout = ({ location, title, children, status }) => {
+const Layout = ({ location, children, status }) => {
   const rootPath = `${__PATH_PREFIX__}/`
   const isRootPath = location.pathname === rootPath
   const cwd = isRootPath ? `~` : `~/posts`
@@ -17,7 +17,11 @@ const Layout = ({ location, title, children, status }) => {
           </Link>
           <nav className="tnav__links" aria-label="Primary">
             <Link to="/">posts</Link>
-            <Link to="/#about">about</Link>
+            {isRootPath ? (
+                <a href="#about">about</a>
+              ) : (
+                <Link to="/#about">about</Link>
+              )}
             <a href="/rss.xml">rss</a>
             <a
               href="https://github.com/roshangautam"

--- a/app/src/components/layout.js
+++ b/app/src/components/layout.js
@@ -11,7 +11,7 @@ const Layout = ({ location, title, children, status }) => {
     <div className="t-shell" data-is-root-path={isRootPath}>
       <header className="tnav">
         <div className="wrap tnav__row">
-          <Link to="/" className="tnav__prompt" aria-label={title}>
+          <Link to="/" className="tnav__prompt">
             <b>roshangautam</b>@blog<span className="dim">:</span>
             {cwd}$
           </Link>

--- a/app/src/components/layout.js
+++ b/app/src/components/layout.js
@@ -1,33 +1,65 @@
 import * as React from "react"
 import { Link } from "gatsby"
 
-const Layout = ({ location, title, children }) => {
+const Layout = ({ location, title, children, status }) => {
   const rootPath = `${__PATH_PREFIX__}/`
   const isRootPath = location.pathname === rootPath
-  let header
-
-  if (isRootPath) {
-    header = (
-      <h1 className="main-heading">
-        <Link to="/">{title}</Link>
-      </h1>
-    )
-  } else {
-    header = (
-      <Link className="header-link-home" to="/">
-        {title}
-      </Link>
-    )
-  }
+  const cwd = isRootPath ? `~` : `~/posts`
+  const year = new Date().getFullYear()
 
   return (
-    <div className="global-wrapper" data-is-root-path={isRootPath}>
-      <header className="global-header">{header}</header>
+    <div className="t-shell" data-is-root-path={isRootPath}>
+      <header className="tnav">
+        <div className="wrap tnav__row">
+          <Link to="/" className="tnav__prompt" aria-label={title}>
+            <b>roshangautam</b>@blog<span className="dim">:</span>
+            {cwd}$
+          </Link>
+          <nav className="tnav__links" aria-label="Primary">
+            <Link to="/">posts</Link>
+            <Link to="/#about">about</Link>
+            <a href="/rss.xml">rss</a>
+            <a
+              href="https://github.com/roshangautam"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              github
+            </a>
+          </nav>
+        </div>
+      </header>
+
       <main>{children}</main>
-      <footer>
-        © {new Date().getFullYear()}
-        {` `}
-        <a href="https://www.roshangautam.com">Roshan Gautam</a>
+
+      <footer className="statusbar">
+        <div className="wrap statusbar__row">
+          <span className="seg">
+            {status || (
+              <>
+                <b>~</b> · utf-8
+              </>
+            )}
+          </span>
+          <nav aria-label="Social">
+            <a
+              href="https://github.com/roshangautam"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              github
+            </a>
+            <a
+              href="https://twitter.com/roshangautam"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              twitter
+            </a>
+            <a href="/rss.xml">rss</a>
+          </nav>
+          <span className="seg">© 2014–{year} roshan gautam</span>
+        </div>
       </footer>
     </div>
   )

--- a/app/src/pages/404.js
+++ b/app/src/pages/404.js
@@ -1,17 +1,42 @@
 import * as React from "react"
-import { graphql } from "gatsby"
+import { Link, graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
 const NotFoundPage = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata.title
+  const status = (
+    <>
+      <b>404</b> · no such file or directory
+    </>
+  )
 
   return (
-    <Layout location={location} title={siteTitle}>
+    <Layout location={location} title={siteTitle} status={status}>
       <Seo title="404: Not Found" />
-      <h1>404: Not Found</h1>
-      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      <section className="wrap hero">
+        <p className="line">
+          <span className="pr">❯</span> cat {location.pathname}
+        </p>
+        <h1 className="hero__name">404</h1>
+        <p className="article__meta">
+          bash: {location.pathname}: command not found
+        </p>
+        <p className="hero__about">
+          That route doesn&#39;t exist. Try{" "}
+          <Link to="/" className="accent">
+            cd ~
+          </Link>{" "}
+          to get back home.
+        </p>
+        <p className="line" style={{ marginTop: `var(--space-lg)` }}>
+          <span className="pr">❯</span>{" "}
+          <Link to="/" className="accent">
+            cd ~
+          </Link>
+        </p>
+      </section>
     </Layout>
   )
 }

--- a/app/src/pages/index.js
+++ b/app/src/pages/index.js
@@ -1,64 +1,98 @@
 import * as React from "react"
 import { Link, graphql } from "gatsby"
 
-import Bio from "../components/bio"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
+const TOPICS = ["mysql", "laravel", "bash", "gatsby", "ai-dev"]
+
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
+  const siteDescription = data.site.siteMetadata?.description || ``
   const posts = data.allMarkdownRemark.nodes
+  const status = (
+    <>
+      <b>~/posts</b> · {posts.length} files · utf-8
+    </>
+  )
 
   if (posts.length === 0) {
     return (
-      <Layout location={location} title={siteTitle}>
+      <Layout location={location} title={siteTitle} status={status}>
         <Seo title="Roshan Gautam" />
-        <Bio />
-        <p>
-          No blog posts found. Add markdown posts to "content/blog" (or the
-          directory you specified for the "gatsby-source-filesystem" plugin in
-          gatsby-config.js).
-        </p>
+        <section className="wrap hero">
+          <p className="line">
+            <span className="pr">❯</span> ls -lt ~/posts
+          </p>
+          <p className="hero__about" id="about">
+            No posts found. Add markdown to <b>content/blog</b>.
+          </p>
+        </section>
       </Layout>
     )
   }
 
   return (
-    <Layout location={location} title={siteTitle}>
+    <Layout location={location} title={siteTitle} status={status}>
       <Seo title="Roshan Gautam" />
-      <Bio />
-      <ol style={{ listStyle: `none` }}>
+
+      <section className="wrap hero">
+        <p className="line">
+          <span className="pr">❯</span> whoami
+        </p>
+        <h1 className="hero__name">
+          Roshan Gautam<span className="blink">_</span>
+        </h1>
+        <p className="line">
+          <span className="pr">❯</span> cat about.txt
+        </p>
+        <p className="hero__about" id="about">
+          {siteDescription}
+        </p>
+        <div className="hero__chips">
+          {TOPICS.map(t => (
+            <span className="chip" key={t}>
+              {t}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="wrap listing">
+        <p className="listing__cmd">
+          <span className="pr">❯</span> ls -lt ~/posts{" "}
+          <span className="dim"># {posts.length} entries, newest first</span>
+        </p>
+        <div className="listing__head" aria-hidden="true">
+          <span>date</span>
+          <span>title</span>
+          <span>type</span>
+        </div>
         {posts.map(post => {
           const title = post.frontmatter.title || post.fields.slug
 
           return (
-            <li key={post.fields.slug}>
-              <article
-                className="post-list-item"
-                itemScope
-                itemType="http://schema.org/Article"
-              >
-                <header>
-                  <h2>
-                    <Link to={post.fields.slug} itemProp="url">
-                      <span itemProp="headline">{title}</span>
-                    </Link>
-                  </h2>
-                  <small>{post.frontmatter.date}</small>
-                </header>
-                <section>
-                  <p
-                    dangerouslySetInnerHTML={{
-                      __html: post.frontmatter.description || post.excerpt,
-                    }}
-                    itemProp="description"
-                  />
-                </section>
-              </article>
-            </li>
+            <Link
+              to={post.fields.slug}
+              className="row reveal"
+              key={post.fields.slug}
+              itemScope
+              itemType="http://schema.org/Article"
+            >
+              <span className="row__date">{post.frontmatter.date}</span>
+              <span className="row__main">
+                <span className="row__title" itemProp="headline">
+                  {title}
+                </span>
+                <span className="row__desc" itemProp="description">
+                  {post.excerpt}
+                </span>
+              </span>
+              <span className="row__ext">.md</span>
+            </Link>
           )
         })}
-      </ol>
+      </section>
     </Layout>
   )
 }
@@ -70,6 +104,7 @@ export const pageQuery = graphql`
     site {
       siteMetadata {
         title
+        description
       }
     }
     allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
@@ -79,7 +114,7 @@ export const pageQuery = graphql`
           slug
         }
         frontmatter {
-          date(formatString: "MMMM DD, YYYY")
+          date(formatString: "YYYY-MM-DD")
           title
           description
         }

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -13,11 +13,6 @@
   box-sizing: border-box;
 }
 
-html,
-body {
-  overflow-x: clip;
-}
-
 body {
   margin: 0;
   background-color: var(--color-paper);
@@ -50,7 +45,9 @@ body::before {
 h1,
 h2,
 h3,
-h4 {
+h4,
+h5,
+h6 {
   font-family: var(--font-mono);
   font-style: normal;
   font-weight: 700;
@@ -113,7 +110,7 @@ a:focus-visible,
    ────────────────────────────────────────────────────────────────── */
 .tnav {
   border-bottom: 1px solid var(--color-rule);
-  background: oklch(15% 0.012 200 / 0.7);
+  background: var(--color-nav-bg);
   backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
@@ -557,7 +554,7 @@ a:focus-visible,
   position: sticky;
   bottom: 0;
   border-top: 1px solid var(--color-rule);
-  background: oklch(14% 0.012 200 / 0.92);
+  background: var(--color-statusbar-bg);
   backdrop-filter: blur(8px);
 }
 .statusbar__row {

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -32,7 +32,6 @@ body {
     transparent 1px
   );
   background-size: 22px 22px;
-  background-attachment: fixed;
 }
 
 /* dot grid faintly, without washing out text */

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -1,337 +1,624 @@
-/* CSS Custom Properties Definitions */
+/* Hallmark · genre: technical · macrostructure: Workbench + Long Document · theme: Terminal · nav: N8 · footer: status bar · design-system: design.md · designed-as-app */
+/* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V5 */
+@import "./tokens.css";
 
-:root {
-    --maxWidth-none: "none";
-    --maxWidth-xs: 20rem;
-    --maxWidth-sm: 24rem;
-    --maxWidth-md: 28rem;
-    --maxWidth-lg: 32rem;
-    --maxWidth-xl: 36rem;
-    --maxWidth-2xl: 42rem;
-    --maxWidth-3xl: 48rem;
-    --maxWidth-4xl: 56rem;
-    --maxWidth-full: "100%";
-    --maxWidth-wrapper: var(--maxWidth-2xl);
-    --spacing-px: "1px";
-    --spacing-0: 0;
-    --spacing-1: 0.25rem;
-    --spacing-2: 0.5rem;
-    --spacing-3: 0.75rem;
-    --spacing-4: 1rem;
-    --spacing-5: 1.25rem;
-    --spacing-6: 1.5rem;
-    --spacing-8: 2rem;
-    --spacing-10: 2.5rem;
-    --spacing-12: 3rem;
-    --spacing-16: 4rem;
-    --spacing-20: 5rem;
-    --spacing-24: 6rem;
-    --spacing-32: 8rem;
-    --fontFamily-sans: Montserrat, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-    --fontFamily-serif: "Merriweather", "Georgia", Cambria, "Times New Roman", Times, serif;
-    --font-body: var(--fontFamily-serif);
-    --font-heading: var(--fontFamily-sans);
-    --fontWeight-normal: 400;
-    --fontWeight-medium: 500;
-    --fontWeight-semibold: 600;
-    --fontWeight-bold: 700;
-    --fontWeight-extrabold: 800;
-    --fontWeight-black: 900;
-    --fontSize-root: 16px;
-    --lineHeight-none: 1;
-    --lineHeight-tight: 1.1;
-    --lineHeight-normal: 1.5;
-    --lineHeight-relaxed: 1.625;
-    /* 1.200 Minor Third Type Scale */
-    --fontSize-0: 0.833rem;
-    --fontSize-1: 1rem;
-    --fontSize-2: 1.2rem;
-    --fontSize-3: 1.44rem;
-    --fontSize-4: 1.728rem;
-    --fontSize-5: 2.074rem;
-    --fontSize-6: 2.488rem;
-    --fontSize-7: 2.986rem;
-    --color-primary: #005b99;
-    --color-text: #2e353f;
-    --color-text-light: #4f5969;
-    --color-heading: #1a202c;
-    --color-heading-black: black;
-    --color-accent: #d1dce5;
-}
-
-
-/* HTML elements */
-
+/* ──────────────────────────────────────────────────────────────────
+   Base
+   normalize.css + prism-tomorrow.css are imported before this file in
+   gatsby-browser.js, so .prose overrides below win on equal specificity.
+   ────────────────────────────────────────────────────────────────── */
 *,
-:after,
-:before {
-    box-sizing: border-box;
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-html {
-    line-height: var(--lineHeight-normal);
-    font-size: var(--fontSize-root);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+html,
+body {
+  overflow-x: clip;
 }
 
 body {
-    font-family: var(--font-body);
-    font-size: var(--fontSize-1);
-    color: var(--color-text);
+  margin: 0;
+  background-color: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  background-image: radial-gradient(
+    var(--color-accent) 1px,
+    transparent 1px
+  );
+  background-size: 22px 22px;
+  background-attachment: fixed;
 }
 
-footer {
-    padding: var(--spacing-6) var(--spacing-0);
+/* dot grid faintly, without washing out text */
+body {
+  background-blend-mode: normal;
 }
-
-hr {
-    background: var(--color-accent);
-    height: 1px;
-    border: 0;
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: var(--color-paper);
+  opacity: 0.95;
+  z-index: -1;
 }
-
-
-/* Heading */
 
 h1,
 h2,
 h3,
-h4,
-h5,
-h6 {
-    font-family: var(--font-heading);
-    margin-top: var(--spacing-12);
-    margin-bottom: var(--spacing-6);
-    line-height: var(--lineHeight-tight);
-    letter-spacing: -0.025em;
-}
-
-h2,
-h3,
-h4,
-h5,
-h6 {
-    font-weight: var(--fontWeight-bold);
-    color: var(--color-heading);
-}
-
-h1 {
-    font-weight: var(--fontWeight-black);
-    font-size: var(--fontSize-6);
-    color: var(--color-heading-black);
-}
-
-h2 {
-    font-size: var(--fontSize-5);
-}
-
-h3 {
-    font-size: var(--fontSize-4);
-}
-
 h4 {
-    font-size: var(--fontSize-3);
+  font-family: var(--font-mono);
+  font-style: normal;
+  font-weight: 700;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+  min-width: 0;
+  margin: 0;
 }
-
-h5 {
-    font-size: var(--fontSize-2);
-}
-
-h6 {
-    font-size: var(--fontSize-1);
-}
-
-h1>a {
-    color: inherit;
-    text-decoration: none;
-}
-
-h2>a,
-h3>a,
-h4>a,
-h5>a,
-h6>a {
-    text-decoration: none;
-    color: inherit;
-}
-
-
-/* Prose */
-
-p {
-    line-height: var(--lineHeight-relaxed);
-    --baseline-multiplier: 0.179;
-    --x-height-multiplier: 0.35;
-    margin: var(--spacing-0) var(--spacing-0) var(--spacing-8) var(--spacing-0);
-    padding: var(--spacing-0);
-}
-
-ul,
-ol {
-    margin-left: var(--spacing-0);
-    margin-right: var(--spacing-0);
-    padding: var(--spacing-0);
-    margin-bottom: var(--spacing-8);
-    list-style-position: outside;
-    list-style-image: none;
-}
-
-ul li,
-ol li {
-    padding-left: var(--spacing-0);
-    margin-bottom: calc(var(--spacing-8) / 2);
-    list-style-position: inside;
-}
-
-li>p {
-    margin-bottom: calc(var(--spacing-8) / 2);
-}
-
-li *:last-child {
-    margin-bottom: var(--spacing-0);
-}
-
-li>ul {
-    margin-left: var(--spacing-8);
-    margin-top: calc(var(--spacing-8) / 2);
-}
-
-blockquote {
-    color: var(--color-text-light);
-    margin-left: calc(-1 * var(--spacing-6));
-    margin-right: var(--spacing-8);
-    padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-6);
-    border-left: var(--spacing-1) solid var(--color-primary);
-    font-size: var(--fontSize-2);
-    font-style: italic;
-    margin-bottom: var(--spacing-8);
-}
-
-blockquote> :last-child {
-    margin-bottom: var(--spacing-0);
-}
-
-blockquote>ul,
-blockquote>ol {
-    list-style-position: inside;
-}
-
-table {
-    width: 100%;
-    margin-bottom: var(--spacing-8);
-    border-collapse: collapse;
-    border-spacing: 0.25rem;
-}
-
-table thead tr th {
-    border-bottom: 1px solid var(--color-accent);
-}
-
-
-/* Link */
 
 a {
-    color: var(--color-primary);
+  color: inherit;
+  text-decoration: none;
 }
 
-a:hover,
-a:focus {
-    text-decoration: none;
+img {
+  max-width: 100%;
+  height: auto;
 }
 
-
-/* Custom classes */
-
-.global-wrapper {
-    margin: var(--spacing-0) auto;
-    max-width: var(--maxWidth-wrapper);
-    padding: var(--spacing-10) var(--spacing-5);
+::selection {
+  background: var(--color-selection);
+  color: var(--color-ink);
 }
 
-.global-wrapper[data-is-root-path="true"] .bio {
-    margin-bottom: var(--spacing-20);
+a:focus-visible,
+.row:focus-visible,
+.np:focus-visible,
+.back:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
 }
 
-.global-header {
-    margin-bottom: var(--spacing-12);
+.wrap {
+  width: 100%;
+  max-width: var(--wrap);
+  margin-inline: auto;
+  padding-inline: var(--space-lg);
 }
 
-.main-heading {
-    font-size: var(--fontSize-7);
-    margin: 0;
+.accent {
+  color: var(--color-accent);
+}
+.dim {
+  color: var(--color-ink-3);
 }
 
-.post-list-item {
-    margin-bottom: var(--spacing-8);
-    margin-top: var(--spacing-8);
+/* shell — keeps the status bar pinned to the bottom on short pages */
+.t-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+.t-shell > main {
+  flex: 1 0 auto;
 }
 
-.post-list-item p {
-    margin-bottom: var(--spacing-0);
+/* ──────────────────────────────────────────────────────────────────
+   Terminal nav (N8)
+   ────────────────────────────────────────────────────────────────── */
+.tnav {
+  border-bottom: 1px solid var(--color-rule);
+  background: oklch(15% 0.012 200 / 0.7);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.tnav__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding-block: var(--space-sm);
+  flex-wrap: wrap;
+}
+.tnav__prompt {
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  white-space: nowrap;
+}
+.tnav__prompt b {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.tnav__links {
+  display: flex;
+  gap: var(--space-md);
+  font-size: var(--text-sm);
+}
+.tnav__links a {
+  color: var(--color-ink-2);
+}
+.tnav__links a::before {
+  content: "./";
+  color: var(--color-ink-3);
+}
+.tnav__links a:hover {
+  color: var(--color-accent);
 }
 
-.post-list-item h2 {
-    font-size: var(--fontSize-4);
-    color: var(--color-primary);
-    margin-bottom: var(--spacing-2);
-    margin-top: var(--spacing-0);
+/* ──────────────────────────────────────────────────────────────────
+   Hero prompt block (home)
+   ────────────────────────────────────────────────────────────────── */
+.hero {
+  padding-block: var(--space-4xl) var(--space-3xl);
+}
+.line {
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  margin: 0 0 var(--space-xs);
+}
+.line .pr {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.hero__name {
+  font-size: var(--text-display-l);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: var(--space-xs) 0;
+  color: var(--color-ink);
+}
+.hero__name .blink {
+  color: var(--color-accent);
+}
+.hero__about {
+  font-size: var(--text-lg);
+  color: var(--color-ink-2);
+  max-width: 42rem;
+  margin: var(--space-md) 0 0;
+  line-height: 1.5;
+}
+.hero__about b {
+  color: var(--color-amber);
+  font-weight: 500;
+}
+.hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  margin-top: var(--space-lg);
+}
+.chip {
+  font-size: var(--text-xs);
+  color: var(--color-ink-2);
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  padding: 0.25rem 0.7rem;
+}
+.chip::before {
+  content: "#";
+  color: var(--color-accent-dim);
 }
 
-.post-list-item header {
-    margin-bottom: var(--spacing-4);
-}
-
-.header-link-home {
-    font-weight: var(--fontWeight-bold);
-    font-family: var(--font-heading);
-    text-decoration: none;
-    font-size: var(--fontSize-2);
-}
-
-.bio {
-    display: flex;
-    margin-bottom: var(--spacing-16);
-}
-
-.bio p {
-    margin-bottom: var(--spacing-0);
-}
-
-.bio-avatar {
-    margin-right: var(--spacing-4);
-    margin-bottom: var(--spacing-0);
-    min-width: 50px;
-    border-radius: 100%;
-}
-
-.blog-post header h1 {
-    margin: var(--spacing-0) var(--spacing-0) var(--spacing-4) var(--spacing-0);
-}
-
-.blog-post header p {
-    font-size: var(--fontSize-2);
-    font-family: var(--font-heading);
-}
-
-.blog-post-nav ul {
-    margin: var(--spacing-0);
-}
-
-.gatsby-highlight {
-    margin-bottom: var(--spacing-8);
-}
-
-
-/* Media queries */
-
-@media (max-width: 42rem) {
-    blockquote {
-        padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-4);
-        margin-left: var(--spacing-0);
+@media (prefers-reduced-motion: no-preference) {
+  .blink {
+    animation: blink 1.05s steps(1) infinite;
+  }
+  @keyframes blink {
+    50% {
+      opacity: 0;
     }
-    ul,
-    ol {
-        list-style-position: inside;
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Listing (ls -lt)
+   ────────────────────────────────────────────────────────────────── */
+.listing {
+  padding-block: var(--space-xl) var(--space-5xl);
+}
+.listing__cmd {
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  margin-bottom: var(--space-lg);
+}
+.listing__cmd .pr {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.listing__head {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr) 4rem;
+  gap: var(--space-md);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding-block: var(--space-xs);
+  border-bottom: 1px solid var(--color-rule);
+}
+.row {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr) 4rem;
+  gap: var(--space-md);
+  align-items: baseline;
+  padding-block: var(--space-md);
+  border-bottom: 1px solid var(--color-rule);
+  transition: background var(--dur) var(--ease-out),
+    padding-left var(--dur) var(--ease-out);
+}
+.row:hover {
+  background: var(--color-paper-2);
+  padding-left: var(--space-sm);
+}
+.row__date {
+  font-size: var(--text-sm);
+  color: var(--color-ink-3);
+  white-space: nowrap;
+}
+.row__main {
+  min-width: 0;
+}
+.row__title {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  color: var(--color-ink);
+  display: inline;
+  line-height: 1.25;
+}
+.row:hover .row__title {
+  color: var(--color-accent);
+}
+.row__title::before {
+  content: "❯ ";
+  color: var(--color-accent-dim);
+  opacity: 0;
+  transition: opacity var(--dur) var(--ease-out);
+}
+.row:hover .row__title::before {
+  opacity: 1;
+}
+.row__desc {
+  display: block;
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  margin: var(--space-xs) 0 0;
+  max-width: 46rem;
+}
+.row__ext {
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  text-align: right;
+  white-space: nowrap;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Article (cat <slug>.md)
+   ────────────────────────────────────────────────────────────────── */
+.article.wrap {
+  max-width: var(--wrap-article);
+}
+.article {
+  padding-block: var(--space-2xl) var(--space-4xl);
+}
+.article__inner {
+  max-width: var(--measure);
+  margin-inline: auto;
+}
+.back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+}
+.back .pr {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.back:hover {
+  color: var(--color-accent);
+}
+.article__cmd {
+  font-size: var(--text-sm);
+  color: var(--color-ink-2);
+  margin-top: var(--space-xl);
+}
+.article__cmd .pr {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.article__title {
+  font-size: var(--text-display);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-top: var(--space-sm);
+  color: var(--color-ink);
+}
+.article__meta {
+  font-size: var(--text-sm);
+  color: var(--color-ink-3);
+  margin-top: var(--space-sm);
+}
+.article__meta .accent {
+  color: var(--color-accent-dim);
+}
+.lede {
+  font-size: var(--text-lg);
+  line-height: 1.5;
+  color: var(--color-ink-2);
+  padding-left: var(--space-md);
+  border-left: 2px solid var(--color-accent-dim);
+  margin-top: var(--space-xl);
+}
+.lede b {
+  color: var(--color-amber);
+  font-weight: 500;
+}
+
+/* ── Prose (rendered markdown body) ── */
+.prose {
+  margin-top: var(--space-2xl);
+}
+.prose > * + * {
+  margin-top: var(--space-lg);
+}
+.prose p {
+  margin: 0;
+}
+.prose em {
+  font-style: italic;
+  color: var(--color-amber);
+}
+.prose strong,
+.prose b {
+  color: var(--color-ink);
+  font-weight: 700;
+}
+.prose h2 {
+  font-size: var(--text-2xl);
+  margin-top: var(--space-2xl);
+}
+.prose h2::before {
+  content: "## ";
+  color: var(--color-accent-dim);
+}
+.prose h3 {
+  font-size: var(--text-xl);
+  margin-top: var(--space-xl);
+}
+.prose h3::before {
+  content: "### ";
+  color: var(--color-accent-dim);
+}
+.prose a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.prose a:hover {
+  color: var(--color-ink);
+}
+.prose ul {
+  list-style: none;
+  padding-left: 0;
+}
+.prose ul > li {
+  position: relative;
+  padding-left: 1.4rem;
+}
+.prose ul > li::before {
+  content: "-";
+  position: absolute;
+  left: 0;
+  color: var(--color-accent);
+}
+.prose ol {
+  list-style: decimal;
+  padding-left: 1.6rem;
+}
+.prose ol > li::marker {
+  color: var(--color-accent-dim);
+}
+.prose li + li {
+  margin-top: var(--space-xs);
+}
+.prose blockquote {
+  margin: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-left: 2px solid var(--color-amber);
+  background: var(--color-paper-2);
+  color: var(--color-ink-2);
+}
+.prose blockquote p {
+  margin: 0;
+}
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--color-rule);
+}
+.prose img {
+  border-radius: var(--radius-md);
+}
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+.prose th,
+.prose td {
+  text-align: left;
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: 1px solid var(--color-rule);
+}
+.prose th {
+  color: var(--color-ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: var(--text-xs);
+}
+
+/* inline code (no language class) */
+.prose :not(pre) > code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--color-code-inline-bg);
+  color: var(--color-accent);
+  padding: 0.1rem 0.36rem;
+  border-radius: var(--radius-sm);
+}
+
+/* ── gatsby-remark-prismjs / prism-tomorrow overrides ──
+   Real posts ship `.gatsby-highlight > pre[class*="language-"] > code`.
+   Higher specificity + later import means these win over prism-tomorrow. */
+.prose .gatsby-highlight {
+  position: relative;
+  margin: 0;
+  max-width: 100%;
+}
+.prose .gatsby-highlight[data-language]::before {
+  content: "# " attr(data-language);
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+  margin-bottom: var(--space-2xs);
+}
+.prose .gatsby-highlight pre[class*="language-"] {
+  margin: 0;
+  background: var(--color-code-bg);
+  color: var(--color-ink);
+  padding: var(--space-md) var(--space-ml);
+  border-left: 2px solid var(--color-accent);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  overflow: auto;
+  max-width: 100%;
+  font-size: 0.84rem;
+  line-height: 1.7;
+}
+.prose .gatsby-highlight pre[class*="language-"] > code {
+  font-family: var(--font-mono);
+  font-size: inherit;
+  background: none;
+  color: inherit;
+  padding: 0;
+  white-space: pre;
+}
+.gatsby-highlight-code-line {
+  display: block;
+  margin-right: calc(-1 * var(--space-ml));
+  margin-left: calc(-1 * var(--space-ml));
+  padding-right: var(--space-ml);
+  padding-left: calc(var(--space-ml) - 2px);
+  border-left: 2px solid var(--color-amber);
+  background: var(--color-paper-2);
+}
+
+/* ── Prev / next ── */
+.article__nextprev {
+  max-width: var(--measure);
+  margin: var(--space-4xl) auto 0;
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--color-rule);
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  flex-wrap: wrap;
+}
+.np {
+  max-width: 18rem;
+}
+.np__label {
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+}
+.np__title {
+  display: block;
+  color: var(--color-ink);
+  margin-top: var(--space-2xs);
+}
+.np:hover .np__title {
+  color: var(--color-accent);
+}
+.np--next {
+  text-align: right;
+  margin-left: auto;
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Status-bar footer
+   ────────────────────────────────────────────────────────────────── */
+.statusbar {
+  position: sticky;
+  bottom: 0;
+  border-top: 1px solid var(--color-rule);
+  background: oklch(14% 0.012 200 / 0.92);
+  backdrop-filter: blur(8px);
+}
+.statusbar__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  padding-block: var(--space-sm);
+  font-size: var(--text-xs);
+  color: var(--color-ink-3);
+}
+.statusbar__row .seg b {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+.statusbar__row nav {
+  display: flex;
+  gap: var(--space-md);
+}
+.statusbar__row nav a:hover {
+  color: var(--color-accent);
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Motion + responsive
+   ────────────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(8px);
+    animation: rise var(--dur) var(--ease-out) forwards;
+  }
+  @keyframes rise {
+    to {
+      opacity: 1;
+      transform: none;
     }
+  }
+}
+
+@media (max-width: 640px) {
+  .listing__head {
+    display: none;
+  }
+  .row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-2xs);
+  }
+  .row__ext {
+    display: none;
+  }
+  .row__date {
+    order: -1;
+  }
+  .article__nextprev {
+    flex-direction: column;
+  }
+  .np--next {
+    text-align: left;
+    margin-left: 0;
+  }
 }

--- a/app/src/templates/blog-post.js
+++ b/app/src/templates/blog-post.js
@@ -1,7 +1,6 @@
 import * as React from "react"
 import { Link, graphql } from "gatsby"
 
-import Bio from "../components/bio"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
@@ -9,57 +8,69 @@ const BlogPostTemplate = ({ data, location }) => {
   const post = data.markdownRemark
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const { previous, next } = data
+  const slug = post.fields?.slug || `/`
+  const filename = slug.replace(/\//g, ``) || `post`
+  const description = post.frontmatter.description
+  const words = post.wordCount?.words
+  const status = (
+    <>
+      <b>{filename}.md</b> · {words} words · utf-8
+    </>
+  )
 
   return (
-    <Layout location={location} title={siteTitle}>
+    <Layout location={location} title={siteTitle} status={status}>
       <Seo
         title={post.frontmatter.title}
         description={post.frontmatter.description || post.excerpt}
         image={post.frontmatter.coverImage}
       />
       <article
-        className="blog-post"
+        className="wrap article"
         itemScope
         itemType="http://schema.org/Article"
       >
-        <header>
-          <h1 itemProp="headline">{post.frontmatter.title}</h1>
-          <p>{post.frontmatter.date}</p>
-        </header>
-        <section
-          dangerouslySetInnerHTML={{ __html: post.html }}
-          itemProp="articleBody"
-        />
-        <hr />
-        <footer>
-          <Bio />
-        </footer>
+        <div className="article__inner">
+          <Link to="/" className="back">
+            <span className="pr">❯</span> cd ..
+          </Link>
+          <p className="article__cmd">
+            <span className="pr">❯</span> cat {filename}.md
+          </p>
+          <h1 className="article__title" itemProp="headline">
+            {post.frontmatter.title}
+          </h1>
+          <p className="article__meta">
+            {post.frontmatter.date}
+            {post.timeToRead ? (
+              <>
+                {" "}
+                <span className="accent">·</span> read: {post.timeToRead} min
+              </>
+            ) : null}
+          </p>
+          {description ? <p className="lede">{description}</p> : null}
+          <div
+            className="prose"
+            dangerouslySetInnerHTML={{ __html: post.html }}
+            itemProp="articleBody"
+          />
+        </div>
       </article>
-      <nav className="blog-post-nav">
-        <ul
-          style={{
-            display: `flex`,
-            flexWrap: `wrap`,
-            justifyContent: `space-between`,
-            listStyle: `none`,
-            padding: 0,
-          }}
-        >
-          <li>
-            {previous && (
-              <Link to={previous.fields.slug} rel="prev">
-                ← {previous.frontmatter.title}
-              </Link>
-            )}
-          </li>
-          <li>
-            {next && (
-              <Link to={next.fields.slug} rel="next">
-                {next.frontmatter.title} →
-              </Link>
-            )}
-          </li>
-        </ul>
+
+      <nav className="wrap article__nextprev" aria-label="Older and newer posts">
+        {previous && (
+          <Link to={previous.fields.slug} rel="prev" className="np np--prev">
+            <span className="np__label">❮ prev</span>
+            <span className="np__title">{previous.frontmatter.title}</span>
+          </Link>
+        )}
+        {next && (
+          <Link to={next.fields.slug} rel="next" className="np np--next">
+            <span className="np__label">next ❯</span>
+            <span className="np__title">{next.frontmatter.title}</span>
+          </Link>
+        )}
       </nav>
     </Layout>
   )
@@ -82,9 +93,16 @@ export const pageQuery = graphql`
       id
       excerpt(pruneLength: 160)
       html
+      timeToRead
+      wordCount {
+        words
+      }
+      fields {
+        slug
+      }
       frontmatter {
         title
-        date(formatString: "MMMM DD, YYYY")
+        date(formatString: "YYYY-MM-DD")
         description
         coverImage
       }

--- a/app/src/templates/blog-post.js
+++ b/app/src/templates/blog-post.js
@@ -11,7 +11,7 @@ const BlogPostTemplate = ({ data, location }) => {
   const slug = post.fields?.slug || `/`
   const filename = slug.replace(/\//g, ``) || `post`
   const description = post.frontmatter.description
-  const words = post.wordCount?.words
+  const words = post.wordCount?.words ?? 0
   const status = (
     <>
       <b>{filename}.md</b> · {words} words · utf-8

--- a/app/src/tokens.css
+++ b/app/src/tokens.css
@@ -20,6 +20,8 @@
 
   /* ── Lines + code surfaces ───────────────────────────────────── */
   --color-rule: oklch(90% 0.02 160 / 0.12);
+  --color-nav-bg: oklch(15% 0.012 200 / 0.7);
+  --color-statusbar-bg: oklch(14% 0.012 200 / 0.92);
   --color-code-bg: oklch(13% 0.012 200);
   --color-code-inline-bg: oklch(86% 0.19 150 / 0.10);
   --color-selection: oklch(86% 0.19 150 / 0.22);

--- a/app/src/tokens.css
+++ b/app/src/tokens.css
@@ -1,0 +1,66 @@
+/* tokens.css — Terminal design system, portable token export.
+ * Reveries of a software engineer. All colour in OKLCH. See design.md.
+ * style.css imports this file and references every token by name. */
+
+:root {
+  /* ── Paper (dark, low-chroma teal) ───────────────────────────── */
+  --color-paper: oklch(17% 0.012 200);
+  --color-paper-2: oklch(21% 0.014 200);
+  --color-paper-3: oklch(25% 0.016 200);
+
+  /* ── Ink ─────────────────────────────────────────────────────── */
+  --color-ink: oklch(90% 0.02 160);
+  --color-ink-2: oklch(72% 0.025 165);
+  --color-ink-3: oklch(58% 0.025 170);
+
+  /* ── Accent (phosphor green) + amber secondary ───────────────── */
+  --color-accent: oklch(86% 0.19 150);
+  --color-accent-dim: oklch(70% 0.14 152);
+  --color-amber: oklch(83% 0.13 75);
+
+  /* ── Lines + code surfaces ───────────────────────────────────── */
+  --color-rule: oklch(90% 0.02 160 / 0.12);
+  --color-code-bg: oklch(13% 0.012 200);
+  --color-code-inline-bg: oklch(86% 0.19 150 / 0.10);
+  --color-selection: oklch(86% 0.19 150 / 0.22);
+
+  /* ── Type ────────────────────────────────────────────────────── */
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", "Menlo", "Consolas",
+    monospace;
+
+  --text-xs: 0.76rem;
+  --text-sm: 0.86rem;
+  --text-base: 0.98rem;
+  --text-lg: 1.18rem;
+  --text-xl: 1.5rem;
+  --text-2xl: clamp(1.5rem, 4.2vw, 2.1rem);
+  --text-display: clamp(1.9rem, 6vw, 3rem);
+  --text-display-l: clamp(2rem, 6.5vw, 3.6rem); /* hero name */
+
+  --measure: 44rem; /* article reading width */
+  --wrap: 64rem; /* home shell width */
+  --wrap-article: 56rem; /* article shell width */
+
+  /* ── Spacing (4pt scale) ─────────────────────────────────────── */
+  --space-2xs: 0.25rem; /* 4 */
+  --space-xs: 0.5rem; /* 8 */
+  --space-sm: 0.75rem; /* 12 */
+  --space-md: 1rem; /* 16 */
+  --space-ml: 1.25rem; /* 20 */
+  --space-lg: 1.5rem; /* 24 */
+  --space-xl: 2rem; /* 32 */
+  --space-2xl: 2.5rem; /* 40 */
+  --space-3xl: 3rem; /* 48 */
+  --space-4xl: 4rem; /* 64 */
+  --space-5xl: 6rem; /* 96 */
+
+  /* ── Motion ──────────────────────────────────────────────────── */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in: cubic-bezier(0.5, 0, 0.84, 0);
+  --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+  --dur: 380ms;
+
+  /* ── Radius ──────────────────────────────────────────────────── */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+}


### PR DESCRIPTION
## Terminal redesign

Refactors the blog to **Direction B "The Terminal"** — a dark, monospace, command-line aesthetic: phosphor-green accent on a near-black low-chroma paper, JetBrains Mono throughout.

### What changed
- **Fonts** — swapped Merriweather/Montserrat for `@fontsource/jetbrains-mono`.
- **Design system** — new OKLCH token source (`app/src/tokens.css`) + a locked, portable system file (`app/design.md`). Global stylesheet rewritten as a single Terminal sheet.
- **Layout** — N8 terminal nav with a cwd-aware prompt (`roshangautam@blog:~/posts$`) and a bottom status bar shell.
- **Home** — hero + an `ls -lt` style post listing.
- **Post template** — terminal article view: `cat <slug>.md` command, computed read time, prev/next pager, `##` heading markers, lede rule.
- **404** — command-not-found screen with a `cd ~` link home.
- **PWA manifest** — name/short_name/colors updated to match.

### Preserved (no functional change)
- All routes and the 8 existing posts (order/content untouched).
- RSS feed at `/rss.xml` (8 items).
- Google Analytics (`UA-28613454-1`).
- Azure Application Insights instrumentation (`gatsby-browser` / `index.js` exports verbatim).
- `staticwebapp.config.json`, `CNAME`, and the CI `swa build` flow.

### Verification
- `gatsby clean && gatsby build` → exit 0; all 8 posts + index + 404 generated.
- Built `public/` confirmed: RSS 8 items, GA id present, App Insights key present, manifest updated.
- Visual + overflow checked at **1280px** (home + post) and **375px** (code-heavy post): `scrollWidth − clientWidth === 0` on the document at every width; code blocks scroll internally inside `<pre>`; nav/status bar wrap cleanly.

🤖 Generated with GitHub Copilot CLI