### PR TITLE
Deploy Azure SWA to production environment on main only

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -21,4 +21,6 @@ jobs:
           node-version: 18
       - run: npm i -g @azure/static-web-apps-cli
       - run: swa build      
-      - run: swa deploy -d ${{ secrets.DEPLOYMENT_TOKEN }} --env production --api-language node --api-version 18
+      - run: swa deploy --env production --api-language node --api-version 18
+        env:
+          SWA_CLI_DEPLOYMENT_TOKEN: ${{ secrets.DEPLOYMENT_TOKEN }}

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -4,7 +4,6 @@ env:
   skip_deploy_on_missing_secrets: true
   
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -22,4 +21,4 @@ jobs:
           node-version: 18
       - run: npm i -g @azure/static-web-apps-cli
       - run: swa build      
-      - run: swa deploy -d ${{ secrets.DEPLOYMENT_TOKEN }} --api-language node --api-version 18
+      - run: swa deploy -d ${{ secrets.DEPLOYMENT_TOKEN }} --env production --api-language node --api-version 18


### PR DESCRIPTION
## What

Make the Azure Static Web Apps workflow deploy to the **production** environment, and only run on merge to `main`.

## Why

The `swa deploy` CLI defaults its `--env` flag to `"preview"` ([Microsoft docs](https://learn.microsoft.com/azure/static-web-apps/static-web-apps-cli-deploy)). The workflow never passed `--env`, so every push to `main` was publishing the site to a **preview** environment rather than production.

## Changes

- Add `--env production` to the `swa deploy` step so merges to `main` deploy to the production SWA environment.
- Remove the `workflow_dispatch` trigger so the workflow runs **only** on merge to `main`. Now that the deploy is hardcoded to production, a manual dispatch from any branch would otherwise push that branch straight to production.

## Notes

- The GitHub Actions `environment: azure` gate (which holds the `DEPLOYMENT_TOKEN` secret) is unchanged.
- Verification is the merge itself: once this lands on `main`, the next deploy run will target the production environment / custom domain instead of a preview URL.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
