### PR TITLE
Add about/portfolio page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 
 .env
+docs/superpowers/

--- a/api/about/data.json
+++ b/api/about/data.json
@@ -1,4 +1,42 @@
 {
-    "name": "Roshan",
-    "description": "Everybody is a nobody but nobody is not everybody"
+  "bio": "Senior Software Engineering Manager at LinkedIn, leading teams that build case management, omni-channel routing, and ML-driven pattern recognition for customer experience. 20+ years across distributed systems, SRE, and developer tooling — from telecom platforms serving millions in Kathmandu, to university smart-campus apps, to enterprise systems at LinkedIn. I care about clean systems, mentoring engineers, and shipping.",
+  "experience": [
+    { "period": "2022—now",  "org": "LinkedIn", "role": "Sr. Software Engineering Manager", "note": "Case management, omni-channel routing & channels, data mining / pattern recognition." },
+    { "period": "2019—2022", "org": "LinkedIn", "role": "Software Engineering Manager", "note": "Enterprise apps across marketing, sales, support." },
+    { "period": "2018—2019", "org": "LinkedIn", "role": "Senior Software Engineer", "note": "" },
+    { "period": "2017—2018", "org": "LinkedIn", "role": "Software Engineer", "note": "Customer-support automation at scale — millions of users, ~25 languages." },
+    { "period": "2012—2017", "org": "Arkansas State University", "role": "Sr. Software Developer", "note": "Smart Campus iOS/Android apps + REST API, symposium & time-tracking systems. Mentored grad students." },
+    { "period": "2010—2012", "org": "Arkansas State University", "role": "Software Developer", "note": "LAMP / SharePoint / MySQL." },
+    { "period": "2005—2009", "org": "ZTE Corporation", "role": "(Sr.) Site Reliability Engineer", "note": "Kathmandu, Nepal. Telecom platforms (SMSC, VMS, WAP, MMSC) for 5M subscribers; tooling in C + shell." }
+  ],
+  "projects": [
+    { "name": "shazam",                  "stars": 7, "lang": "C#",  "desc": "Power Apps solution boilerplate & generator", "url": "https://github.com/roshangautam/shazam" },
+    { "name": "shazam-framework",        "stars": 2, "lang": "C#",  "desc": ".NET CLI for Power Platform development",     "url": "https://github.com/roshangautam/shazam-framework" },
+    { "name": "microsoft-dynamics-auth", "stars": 3, "lang": "Py",  "desc": "Dynamics 365 auth plugin for HTTPie",         "url": "https://github.com/roshangautam/microsoft-dynamics-auth" },
+    { "name": "sentinel-ldap",           "stars": 3, "lang": "PHP", "desc": "LDAP addon for Laravel Sentinel",            "url": "https://github.com/roshangautam/sentinel-ldap" },
+    { "name": "cmm-compiler",            "stars": 3, "lang": "C++", "desc": "Compiler for a C-minus-minus language",       "url": "https://github.com/roshangautam/cmm-compiler" },
+    { "name": "radiosity-engine",        "stars": 0, "lang": "C++", "desc": "Global-illumination rendering engine",       "url": "https://github.com/roshangautam/radiosity-engine" }
+  ],
+  "skills": {
+    "languages":  "Java · C# · Python · C++ · PHP · Bash · TypeScript",
+    "systems":    "Distributed Systems · SRE · Linux · ETL / HDFS",
+    "platforms":  "Azure · Power Platform · Gatsby · Laravel · MySQL",
+    "leadership": "Engineering Management · Mentoring · CI/CD · SOLID"
+  },
+  "contact": {
+    "email":    "contact@roshangautam.net",
+    "github":   "github.com/roshangautam",
+    "linkedin": "linkedin.com/in/roshangautam",
+    "twitter":  "twitter.com/roshangautam"
+  },
+  "education": [
+    { "degree": "M.S. Computer Science",     "org": "Arkansas State University",       "year": "2017" },
+    { "degree": "M.S. Engineering Management","org": "Arkansas State University",       "year": "2012" },
+    { "degree": "B.E. Computer Engineering",  "org": "Kantipur Engineering College",    "year": "2004" }
+  ],
+  "certifications": [
+    "Microsoft Azure Fundamentals",
+    "Microsoft Power Platform Fundamentals",
+    "gRPC Master Class"
+  ]
 }

--- a/api/about/index.ts
+++ b/api/about/index.ts
@@ -1,6 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions"
-// Note: this function runs from `dist/` (see function.json), so load JSON from the source folder.
-import data = require("../../about/data.json")
+import data = require("./data.json")
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
     context.res = {
         status: 200,

--- a/api/about/index.ts
+++ b/api/about/index.ts
@@ -1,17 +1,14 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+import data = require("./data.json")
 
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
-    context.log('HTTP trigger function processed a request.');
-    const name = (req.query.name || (req.body && req.body.name));
-    const responseMessage = name
-        ? "Hello, " + name + ". This HTTP triggered function executed successfully."
-        : "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.";
-
     context.res = {
-        // status: 200, /* Defaults to 200 */
-        body: responseMessage
+        status: 200,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: data
     };
-
 };
 
 export default httpTrigger;

--- a/api/about/index.ts
+++ b/api/about/index.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions"
-import data = require("./data.json")
-
+// Note: this function runs from `dist/` (see function.json), so load JSON from the source folder.
+import data = require("../../about/data.json")
 const httpTrigger: AzureFunction = async function (context: Context, req: HttpRequest): Promise<void> {
     context.res = {
         status: 200,

--- a/app/src/components/layout.js
+++ b/app/src/components/layout.js
@@ -17,11 +17,7 @@ const Layout = ({ location, children, status }) => {
           </Link>
           <nav className="tnav__links" aria-label="Primary">
             <Link to="/">posts</Link>
-            {isRootPath ? (
-                <a href="#about">about</a>
-              ) : (
-                <Link to="/#about">about</Link>
-              )}
+            <Link to="/about">about</Link>
             <a href="/rss.xml">rss</a>
             <a
               href="https://github.com/roshangautam"

--- a/app/src/components/layout.js
+++ b/app/src/components/layout.js
@@ -4,7 +4,11 @@ import { Link } from "gatsby"
 const Layout = ({ location, children, status }) => {
   const rootPath = `${__PATH_PREFIX__}/`
   const isRootPath = location.pathname === rootPath
-  const cwd = isRootPath ? `~` : `~/posts`
+  const cwd = isRootPath
+    ? `~`
+    : location.pathname.startsWith(`${__PATH_PREFIX__}/about`)
+    ? `~/about`
+    : `~/posts`
   const year = new Date().getFullYear()
 
   return (

--- a/app/src/pages/about.js
+++ b/app/src/pages/about.js
@@ -1,0 +1,220 @@
+import * as React from "react"
+
+import Layout from "../components/layout"
+import Seo from "../components/seo"
+
+const SITE_TITLE = `Reveries of a software engineer`
+const SECTION_COUNT = 7
+
+const contactHref = (key, value) => {
+  if (key === "email") {
+    return `mailto:${value}`
+  }
+
+  return `https://${value.replace(/^https?:\/\//, "")}`
+}
+
+const AboutPage = ({ location }) => {
+  const [about, setAbout] = React.useState(null)
+  const [error, setError] = React.useState(false)
+  const sectionCount = about && !error ? SECTION_COUNT : 0
+  const status = (
+    <>
+      <b>~/about</b> · {sectionCount} sections · utf-8
+    </>
+  )
+
+  React.useEffect(() => {
+    let mounted = true
+
+    fetch("/api/about")
+      .then(res => {
+        if (!res.ok) {
+          throw new Error("Could not load about data")
+        }
+
+        return res.json()
+      })
+      .then(data => {
+        if (mounted) {
+          setAbout(data)
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setError(true)
+        }
+      })
+
+    return () => {
+      mounted = false
+    }
+  }, [])
+
+  if (error) {
+    return (
+      <Layout location={location} title={SITE_TITLE} status={status}>
+        <Seo title="About" />
+        <section className="wrap hero">
+          <p className="line">
+            <span className="pr">❯</span> cat about.json
+          </p>
+          <p className="line dim">cat: about.json: could not load</p>
+        </section>
+      </Layout>
+    )
+  }
+
+  if (!about) {
+    return (
+      <Layout location={location} title={SITE_TITLE} status={status}>
+        <Seo title="About" />
+        <section className="wrap hero">
+          <p className="line about-loading">
+            <span className="pr">❯</span> cat about.json
+            <span className="blink">_</span>
+          </p>
+        </section>
+      </Layout>
+    )
+  }
+
+  const experience = about.experience || []
+  const projects = about.projects || []
+  const skills = about.skills || {}
+  const contact = about.contact || {}
+  const education = about.education || []
+  const certifications = about.certifications || []
+  const skillRows = ["languages", "systems", "platforms", "leadership"]
+  const contactRows = ["email", "github", "linkedin", "twitter"]
+
+  return (
+    <Layout location={location} title={SITE_TITLE} status={status}>
+      <Seo title="About" />
+
+      <section className="wrap hero reveal">
+        <p className="line">
+          <span className="pr">❯</span> whoami
+        </p>
+        <h1 className="hero__name">
+          Roshan Gautam<span className="blink">_</span>
+        </h1>
+        <p className="line">
+          <span className="pr">❯</span> cat about.txt
+        </p>
+        <p className="hero__about">{about.bio}</p>
+      </section>
+
+      <section className="wrap reveal">
+        <p className="line">
+          <span className="pr">❯</span> cat experience.log
+        </p>
+        <div className="log">
+          {experience.map(item => (
+            <div key={`${item.period}-${item.org}-${item.role}`}>
+              <span>{item.period}</span>
+              <span>
+                <b>
+                  {item.org} · {item.role}
+                </b>
+                {item.note ? <span>{item.note}</span> : null}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="wrap listing reveal">
+        <p className="line">
+          <span className="pr">❯</span> ls -lt ~/projects
+        </p>
+        <div className="listing__head" aria-hidden="true">
+          <span>stars</span>
+          <span>name</span>
+          <span>lang</span>
+        </div>
+        {projects.map(project => (
+          <a
+            href={project.url}
+            className="row reveal"
+            key={project.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="row__date">
+              {project.stars > 0 ? `★${project.stars}` : ``}
+            </span>
+            <span className="row__main">
+              <span className="row__title">{project.name}</span>
+              <span className="row__desc">{project.desc}</span>
+            </span>
+            <span className="row__ext">{project.lang}</span>
+          </a>
+        ))}
+      </section>
+
+      <section className="wrap reveal">
+        <p className="line">
+          <span className="pr">❯</span> cat skills.txt
+        </p>
+        <div className="kv">
+          {skillRows.map(key => (
+            <div key={key}>
+              <span>{key}</span>
+              <span>{skills[key]}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="wrap reveal">
+        <p className="line">
+          <span className="pr">❯</span> cat contact.txt
+        </p>
+        <div className="kv">
+          {contactRows.map(key => (
+            <div key={key}>
+              <span>{key}</span>
+              <span>
+                {contact[key] ? (
+                  <a
+                    href={contactHref(key, contact[key])}
+                    target={key === "email" ? undefined : "_blank"}
+                    rel={key === "email" ? undefined : "noopener noreferrer"}
+                  >
+                    {contact[key]}
+                  </a>
+                ) : null}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="wrap reveal">
+        <p className="line">
+          <span className="pr">❯</span> cat education.txt
+        </p>
+        <div className="kv">
+          {education.map(item => (
+            <div key={`${item.year}-${item.degree}`}>
+              <span>{item.year}</span>
+              <span>
+                {item.degree} · {item.org}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="wrap reveal">
+        <p className="line">
+          <span className="pr">❯</span> cat certs.txt
+        </p>
+        <p className="line">{certifications.join(" · ")}</p>
+      </section>
+    </Layout>
+  )
+}
+
+export default AboutPage

--- a/app/src/style.css
+++ b/app/src/style.css
@@ -295,6 +295,64 @@ a:focus-visible,
   white-space: nowrap;
 }
 
+.log {
+  margin: var(--space-lg) 0 var(--space-3xl);
+}
+.log > div {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  gap: var(--space-md);
+  align-items: baseline;
+  padding-block: var(--space-md);
+  border-bottom: 1px solid var(--color-rule);
+}
+.log > div > span:first-child {
+  font-size: var(--text-sm);
+  color: var(--color-ink-3);
+  white-space: nowrap;
+}
+.log > div > span:last-child {
+  color: var(--color-ink-2);
+}
+.log b {
+  display: block;
+  color: var(--color-ink);
+  font-weight: 700;
+}
+.log b + span {
+  display: block;
+  color: var(--color-ink-2);
+  font-size: var(--text-sm);
+  margin-top: var(--space-xs);
+}
+
+.kv {
+  margin: var(--space-lg) 0 var(--space-3xl);
+}
+.kv > div {
+  display: grid;
+  grid-template-columns: 8.5rem minmax(0, 1fr);
+  gap: var(--space-md);
+  align-items: baseline;
+  padding-block: var(--space-sm);
+  border-bottom: 1px solid var(--color-rule);
+}
+.kv > div > span:first-child {
+  font-size: var(--text-sm);
+  color: var(--color-ink-3);
+  white-space: nowrap;
+}
+.kv > div > span:last-child {
+  color: var(--color-ink-2);
+}
+.kv a:hover {
+  color: var(--color-accent);
+}
+
+.about-loading {
+  display: block;
+}
+
 /* ──────────────────────────────────────────────────────────────────
    Article (cat <slug>.md)
    ────────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## What

Adds an `/about` portfolio page in the existing terminal aesthetic.

- **`app/src/pages/about.js`** — new Gatsby page; client-side `fetch("/api/about")` in `useEffect` with loading + error states. Renders 7 sections (bio, experience, projects, skills, contact, education, certs). Mirrors `index.js`, reuses locked classes.
- **`api/about/index.ts` + `data.json`** — the existing Azure Function now serves real portfolio content as JSON.
- **`app/src/components/layout.js`** — nav `about` → `/about`.
- **`app/src/style.css`** — 3 new classes (`.log`, `.kv`, `.about-loading`).

## Verification

- `gatsby build` → exit 0, `/about/` generated.
- `api/` `npm run build` → compiles; handler returns 200 JSON.
- Local preview: `/about`, `/`, `/api/about` all 200, page hydrates and fetches real data.

No new deps, plugins, or GraphQL. Build output is the loading state (doesn't need the API running).