### PR TITLE
chore: remove dead Google Analytics plugin

### DIFF
--- a/app/gatsby-config.js
+++ b/app/gatsby-config.js
@@ -59,12 +59,6 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: `UA-28613454-1`,
-      },
-    },
-    {
       resolve: `gatsby-plugin-feed`,
       options: {
         query: `

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,6 @@
         "gatsby": "^5.16.1",
         "gatsby-plugin-feed": "5.3.1",
         "gatsby-plugin-gatsby-cloud": "5.3.1",
-        "gatsby-plugin-google-analytics": "^5.3.0",
         "gatsby-plugin-image": "3.3.2",
         "gatsby-plugin-manifest": "5.3.1",
         "gatsby-plugin-offline": "6.3.1",
@@ -10847,47 +10846,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/gatsby-plugin-google-analytics": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-5.14.0.tgz",
-      "integrity": "sha512-mzUXk+0nmRKYJilKtZFaajO05MYM1aDd3LkJYDH7kDhgiiAjHo9n404n3I2D7/3G7ikxmlY31zg7y6EsIzZX7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "minimatch": "^3.1.2",
-        "web-vitals": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "react": "^18.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^0.0.0"
-      }
-    },
-    "node_modules/gatsby-plugin-google-analytics/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/gatsby-plugin-google-analytics/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/gatsby-plugin-image": {
@@ -22272,12 +22230,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig==",
-      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,6 @@
     "gatsby": "^5.16.1",
     "gatsby-plugin-feed": "5.3.1",
     "gatsby-plugin-gatsby-cloud": "5.3.1",
-    "gatsby-plugin-google-analytics": "^5.3.0",
     "gatsby-plugin-image": "3.3.2",
     "gatsby-plugin-manifest": "5.3.1",
     "gatsby-plugin-offline": "6.3.1",


### PR DESCRIPTION
## What

Removes `gatsby-plugin-google-analytics` (tracking ID `UA-28613454-1`).

## Why

Universal Analytics **stopped processing hits on July 1, 2023**, so this plugin has been collecting nothing for over a year. Dead weight in the build + a stale dependency.

Azure Application Insights remains the in-app telemetry path and is **untouched** by this change.

## Changes
- Drop the plugin config block from `gatsby-config.js`
- Remove the dependency from `package.json` + `package-lock.json`

## Verification
- `gatsby build` passes (exit 0)
- No residual `google-analytics` / `gtag` / `UA-28613454` refs in source

> Note: while validating this, App Insights browser telemetry was found to be reporting **0 pageViews over 7 days** — tracked separately, not addressed here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>