### PR TITLE
fix: render about page from static data (works on GitHub Pages)

### DIFF
--- a/app/src/pages/about.js
+++ b/app/src/pages/about.js
@@ -3,8 +3,8 @@ import * as React from "react"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
-// ponytail: about data is fully static; import it at build time so the page renders
-// on GitHub Pages too. Azure SWA served it via /api/about, which Pages can't run.
+// About data is fully static; import it at build time so the page renders on GitHub Pages too.
+// Azure SWA served it via /api/about, which GitHub Pages can't run.
 import about from "../../../api/about/data.json"
 
 const SITE_TITLE = `Reveries of a software engineer`

--- a/app/src/pages/about.js
+++ b/app/src/pages/about.js
@@ -3,6 +3,10 @@ import * as React from "react"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
+// ponytail: about data is fully static; import it at build time so the page renders
+// on GitHub Pages too. Azure SWA served it via /api/about, which Pages can't run.
+import about from "../../../api/about/data.json"
+
 const SITE_TITLE = `Reveries of a software engineer`
 const SECTION_COUNT = 7
 
@@ -15,69 +19,11 @@ const contactHref = (key, value) => {
 }
 
 const AboutPage = ({ location }) => {
-  const [about, setAbout] = React.useState(null)
-  const [error, setError] = React.useState(false)
-  const sectionCount = about && !error ? SECTION_COUNT : 0
   const status = (
     <>
-      <b>~/about</b> · {sectionCount} sections · utf-8
+      <b>~/about</b> · {SECTION_COUNT} sections · utf-8
     </>
   )
-
-  React.useEffect(() => {
-    let mounted = true
-
-    fetch("/api/about")
-      .then(res => {
-        if (!res.ok) {
-          throw new Error("Could not load about data")
-        }
-
-        return res.json()
-      })
-      .then(data => {
-        if (mounted) {
-          setAbout(data)
-        }
-      })
-      .catch(() => {
-        if (mounted) {
-          setError(true)
-        }
-      })
-
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  if (error) {
-    return (
-      <Layout location={location} title={SITE_TITLE} status={status}>
-        <Seo title="About" />
-        <section className="wrap hero">
-          <p className="line">
-            <span className="pr">❯</span> cat about.json
-          </p>
-          <p className="line dim">cat: about.json: could not load</p>
-        </section>
-      </Layout>
-    )
-  }
-
-  if (!about) {
-    return (
-      <Layout location={location} title={SITE_TITLE} status={status}>
-        <Seo title="About" />
-        <section className="wrap hero">
-          <p className="line about-loading">
-            <span className="pr">❯</span> cat about.json
-            <span className="blink">_</span>
-          </p>
-        </section>
-      </Layout>
-    )
-  }
 
   const experience = about.experience || []
   const projects = about.projects || []


### PR DESCRIPTION
## Problem

The about page works on Azure Static Web Apps but renders **`cat: about.json: could not load`** on GitHub Pages.

**Root cause:** `app/src/pages/about.js` fetched `/api/about` at runtime inside a `useEffect`. Azure SWA serves that endpoint via a managed Azure Function, but **GitHub Pages is static-only** — there's no `/api/*` to hit, so the fetch 404s and the error branch renders.

## Fix

The `/api/about` Function (`api/about/index.ts`) just `require`s `api/about/data.json` and returns it verbatim — **zero dynamic behavior**. So there's no reason to fetch at runtime.

This PR imports that JSON at build time and removes the `useEffect` fetch plus the `useState`/`error`/loading branches. The page now renders as static HTML at build time.

- ✅ Works on **GitHub Pages** (no runtime API needed)
- ✅ Still works on **Azure SWA** (same rendered output)
- ✅ Data **single-sourced** from the existing `api/about/data.json` — no duplication/drift
- Net diff: **+5 / −59** lines

## Verification

`gatsby clean && gatsby build` (exit 0), then confirmed the built `public/about/index.html`:
- contains the real bio (`Senior Software Engineering Manager`)
- no longer contains `could not load`

## Out of scope (optional follow-up)

The `api/about/` Azure Function is now unused. Leaving it is harmless; removing it would expand the diff (touches Azure API wiring + built `dist/`). Shortest-working-diff wins.
